### PR TITLE
Solve 스타트와 링크

### DIFF
--- a/BOJ/스타트와 링크.py
+++ b/BOJ/스타트와 링크.py
@@ -1,0 +1,52 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+stat = []
+
+for _ in range(N):
+    stat.append(list(map(int, input().split())))
+team_start = [False for _ in range(N)]    
+
+ans = 10e9
+def calculate_stat():
+    global ans
+    s = []
+    l = []
+    for n in range(N):
+        if team_start[n] == True:
+            s.append(n)
+        else:
+            l.append(n)
+    
+    stat_s = 0
+    for i in s:
+        for j in s:
+            if not i==j:
+                stat_s+=stat[i][j]
+    stat_l = 0
+    for i in l:
+        for j in l:
+            if not i==j:
+                stat_l+=stat[i][j]
+    
+    ans = min(ans, abs(stat_s - stat_l))
+            
+    
+
+def pick(index, cnt):
+    while True:
+        if cnt == N//2:
+            calculate_stat()
+            return
+        if index >= N:
+            return
+        
+        if team_start[index] == False:
+            team_start[index] = True
+            pick(index+1, cnt+1)
+            team_start[index] = False
+        index+=1
+
+pick(0, 0)
+print(ans)


### PR DESCRIPTION
### 아이디어

#브루트포스 #백트래킹

스타트 팀과 링크 팀을 나누는 모든 경우의 수 탐색

### 알고리즘

1. 스타트 팀을 고르는 pick 함수 호출
2. pick: 순차적으로 사람을 골라 스타트 팀으로 표시하고, N/2명을 고를 때까지 다음 사람부터 재시작하도록 자신을 재귀 호출
    1. N/2명을 모두 고르면 각 팀의 능력치를 계산하는 calculate_stat 함수 호출
3. calculate_stat: 모든 조합의 능력치를 더하여 각 팀의 능력치를 구하고, 각 팀의 능력치 간 차이를 저장

능력치 간 차이 중 최솟값을 출력